### PR TITLE
Concurrent indexing (fixes #4)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Run golangci-lint before every push. Install with:
+#   git config core.hooksPath .githooks
+set -e
+echo "Running golangci-lint..."
+GOTOOLCHAIN=local golangci-lint run

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        go-version: '1.24.x'
         cache: true
 
     - name: Tidy Go modules
@@ -37,5 +37,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: fafi2-stable
+        name: fafi2
         path: tmp/fafi2

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -10,28 +10,18 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['stable']
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Go ${{ matrix.go-version }}
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
-
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version: stable
+        cache: true
 
     - name: Tidy Go modules
-      run: go mod tidy
+      run: go mod tidy && git diff --exit-code go.mod go.sum
 
     - name: Lint
       uses: golangci/golangci-lint-action@v7
@@ -39,25 +29,13 @@ jobs:
         version: v2.0
 
     - name: Test
-      run: go test -v ./...
+      run: go test -race -tags fts5 -v ./...
 
     - name: Build
-      env:
-        MY_ENV_VAR: ${{ secrets.MY_ENV_VAR }}
-      run: |
-        go build --tags fts5 -o tmp/fafi2 fafi2
-
-    - name: Test Build
-      run: |
-        if [ -f tmp/fafi2 ]; then
-          echo "Build succeeded"
-        else
-          echo "Build failed"
-          exit 1
-        fi
+      run: go build --tags fts5 -o tmp/fafi2 fafi2
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: fafi2-${{ matrix.go-version }}
+        name: fafi2-stable
         path: tmp/fafi2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.26"
   build-tags:
     - fts5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 version: "2"
 run:
-  go: "1.26"
+  go: "1.24"
   build-tags:
     - fts5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+run:
+  go: "1.24"
+  build-tags:
+    - fts5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,8 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-linters-settings:
-  staticcheck:
-    checks:
-      - "SA*"  # safety-critical: bugs, correctness
-      - "S1*"  # simplifications
-issues:
-  exclude-dirs-use-default: true  # skip vendor/, testdata/, generated code
+  settings:
+    staticcheck:
+      checks:
+        - "SA*"  # safety-critical: bugs, correctness
+        - "S1*"  # simplifications

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,10 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+linters-settings:
+  staticcheck:
+    checks:
+      - "SA*"  # safety-critical: bugs, correctness
+      - "S1*"  # simplifications
+issues:
+  exclude-dirs-use-default: true  # skip vendor/, testdata/, generated code

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,10 @@ run:
   go: "1.24"
   build-tags:
     - fts5
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,15 @@ Always run with `-race` to catch data races. Follow **red-green TDD**: write the
 GOTOOLCHAIN=local golangci-lint run
 ```
 
-**Always check lint passes before pushing.** A pre-push hook enforces this automatically (see `~/.claude/settings.json`).
+**Always check lint passes before pushing.**
+
+A git pre-push hook is committed in `.githooks/pre-push`. Activate it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+A Claude Code hook also enforces this automatically on `git push` (see `~/.claude/settings.json`).
 
 Configuration is in `.golangci.yml`:
 - `run.go: "1.24"` — targets Go 1.24 semantics; prevents false typecheck errors from Go stdlib files with `//go:build go1.26` constraints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# fafi development notes
+
+## Build
+
+```bash
+GOTOOLCHAIN=local go build --tags fts5 -o tmp/fafi2 fafi2
+```
+
+The `fts5` tag enables the SQLite FTS5 full-text search extension (required).
+`GOTOOLCHAIN=local` prevents Go from attempting to auto-download a newer toolchain.
+
+## Test
+
+```bash
+GOTOOLCHAIN=local go test -race ./...
+```
+
+Always run with `-race` to catch data races. Follow **red-green TDD**: write the failing test first, then make it pass.
+
+## Lint
+
+```bash
+GOTOOLCHAIN=local golangci-lint run
+```
+
+**Always check lint passes before pushing.** A pre-push hook enforces this automatically (see `~/.claude/settings.json`).
+
+Configuration is in `.golangci.yml`:
+- `run.go: "1.24"` — targets Go 1.24 semantics; prevents false typecheck errors from Go stdlib files with `//go:build go1.26` constraints
+- `build-tags: [fts5]` — ensures lint sees the same code as the build
+
+## Go version
+
+- Module requires `go 1.24.7` (see `go.mod`)
+- Local toolchain: `go1.24.7`
+- Use `GOTOOLCHAIN=local` in all local commands to prevent auto-download attempts
+
+## Workflow learnings
+
+- `actions/setup-go@v5` has built-in caching — no need for a separate `actions/cache` step
+- `go mod tidy && git diff --exit-code go.mod go.sum` in CI catches drift that a silent tidy masks
+- Single-element `strategy.matrix` adds overhead with no benefit; set `go-version` directly
+- `go build` exits non-zero on failure — a separate file-existence check is redundant
+- The `for {}` loop in `bootIndexer` was unconditionally terminated (`SA4004`) — removed the dead wrapper
+- Goroutines capturing an outer `err` variable after a void function call is a logic bug — always check what a function actually returns

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fafi2
 
-go 1.23.0
+go 1.24
 
 toolchain go1.24.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module fafi2
 
-go 1.26.1
-
-toolchain go1.26.1
+go 1.24.7
 
 require (
 	github.com/advancedlogic/GoOse v0.0.0-20230923151002-b0edce1b52f8

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module fafi2
 
-go 1.24
+go 1.26.1
 
-toolchain go1.24.1
+toolchain go1.26.1
 
 require (
 	github.com/advancedlogic/GoOse v0.0.0-20230923151002-b0edce1b52f8

--- a/main.go
+++ b/main.go
@@ -66,19 +66,16 @@ func indexQueue(queue []bookmark.Bookmark, indexFn func(bookmark.Bookmark)) {
 
 // Index any bookmarks without text
 func bootIndexer() {
-	for {
-		queue, err := bookmark.BmDb.SelectQueue()
-		log.Printf("Indexing queue has %d bookmarks\n", len(queue))
-		if err != nil {
-			log.Println("Queue init error:", err)
-			return
-		}
-		indexQueue(queue, func(bm bookmark.Bookmark) {
-			bookmark.Index(bm)
-			log.Println("Indexed " + bm.URL)
-		})
+	queue, err := bookmark.BmDb.SelectQueue()
+	log.Printf("Indexing queue has %d bookmarks\n", len(queue))
+	if err != nil {
+		log.Println("Queue init error:", err)
 		return
 	}
+	indexQueue(queue, func(bm bookmark.Bookmark) {
+		bookmark.Index(bm)
+		log.Println("Indexed " + bm.URL)
+	})
 }
 
 // bootServer Starts Web Server


### PR DESCRIPTION
## Summary

- Adds concurrent bookmark indexing using goroutines + `sync.WaitGroup`, replacing the sequential loop
- Extracts `indexQueue(queue, indexFn)` helper to keep concurrency logic testable
- Fixes bug from original PR #133: removed dead `if err != nil` inside goroutine that captured the outer `SelectQueue` error instead of checking `Index`'s result (`Index` returns void)
- Adds `TestIndexQueueCallsAllBookmarks` — runs with `-race` to verify all bookmarks are processed and no data races occur
- Adds `.golangci.yml` with `run.go: "1.24"` and `build-tags: [fts5]` to fix CI lint failures (x/crypto go1.26 typecheck cascade, missing FTS5 tag)
- Updates Go to 1.24.7

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go build --tags fts5 ./...` succeeds locally
- [x] `go vet ./...` clean
- [ ] CI `build (stable)` passes

https://claude.ai/code/session_014vpdL1mwDPJw5Tys6XXuV8